### PR TITLE
Add support for zipping two parallel streams into a new parallel stream

### DIFF
--- a/src/main/java/com/codepoetics/protonpack/StreamUtils.java
+++ b/src/main/java/com/codepoetics/protonpack/StreamUtils.java
@@ -35,7 +35,7 @@ public final class StreamUtils {
      * @return A stream of indexed values.
      */
     public static <T> Stream<Indexed<T>> zipWithIndex(Stream<T> source) {
-        return zip(indices().mapToObj(Long::valueOf), source, Indexed::index);
+        return null;
     }
 
     /**
@@ -52,7 +52,7 @@ public final class StreamUtils {
      */
     public static <L, R, O> Stream<O> zip(Stream<L> lefts, Stream<R> rights, BiFunction<L, R, O> combiner) {
     	boolean isParallel = lefts.isParallel() && rights.isParallel();
-        return StreamSupport.stream(ZippingSpliterator.zipping(lefts.spliterator(), rights.spliterator(), combiner, isParallel), isParallel);
+        return StreamSupport.stream(ZippingSpliterator.zipping(lefts.spliterator(), rights.spliterator(), combiner), isParallel);
     }
 
     private static boolean isSized(int characteristics) {

--- a/src/main/java/com/codepoetics/protonpack/StreamUtils.java
+++ b/src/main/java/com/codepoetics/protonpack/StreamUtils.java
@@ -35,7 +35,7 @@ public final class StreamUtils {
      * @return A stream of indexed values.
      */
     public static <T> Stream<Indexed<T>> zipWithIndex(Stream<T> source) {
-        return null;
+        return zip(indices().mapToObj(Long::valueOf), source, Indexed::index);
     }
 
     /**

--- a/src/main/java/com/codepoetics/protonpack/StreamUtils.java
+++ b/src/main/java/com/codepoetics/protonpack/StreamUtils.java
@@ -51,7 +51,8 @@ public final class StreamUtils {
      * @return A stream of zipped values.
      */
     public static <L, R, O> Stream<O> zip(Stream<L> lefts, Stream<R> rights, BiFunction<L, R, O> combiner) {
-        return StreamSupport.stream(ZippingSpliterator.zipping(lefts.spliterator(), rights.spliterator(), combiner), false);
+    	boolean isParallel = lefts.isParallel() && rights.isParallel();
+        return StreamSupport.stream(ZippingSpliterator.zipping(lefts.spliterator(), rights.spliterator(), combiner, isParallel), isParallel);
     }
 
     private static boolean isSized(int characteristics) {

--- a/src/main/java/com/codepoetics/protonpack/ZippingSpliterator.java
+++ b/src/main/java/com/codepoetics/protonpack/ZippingSpliterator.java
@@ -7,21 +7,19 @@ import java.util.function.Consumer;
 
 class ZippingSpliterator<L, R, O> implements Spliterator<O> {
 
-    static <L, R, O> Spliterator<O> zipping(Spliterator<L> lefts, Spliterator<R> rights, BiFunction<L, R, O> combiner, boolean isParallel) {
-        return new ZippingSpliterator<>(lefts, rights, combiner, isParallel);
+    static <L, R, O> Spliterator<O> zipping(Spliterator<L> lefts, Spliterator<R> rights, BiFunction<L, R, O> combiner) {
+        return new ZippingSpliterator<>(lefts, rights, combiner);
     }
 
     private final Spliterator<L> lefts;
     private final Spliterator<R> rights;
     private final BiFunction<L, R, O> combiner;
     private boolean rightHadNext = false;
-    private boolean isParallel;
 
-    private ZippingSpliterator(Spliterator<L> lefts, Spliterator<R> rights, BiFunction<L, R, O> combiner, boolean isParallel) {
+    private ZippingSpliterator(Spliterator<L> lefts, Spliterator<R> rights, BiFunction<L, R, O> combiner) {
         this.lefts = lefts;
         this.rights = rights;
         this.combiner = combiner;
-        this.isParallel = isParallel;
     }
 
     @Override
@@ -37,9 +35,6 @@ class ZippingSpliterator<L, R, O> implements Spliterator<O> {
 
     @Override
     public Spliterator<O> trySplit() {
-    	if(!isParallel){
-    		return null;
-    	}
     	Spliterator<L> newLefts = lefts.trySplit();
     	if(newLefts == null){
     		return null;
@@ -48,7 +43,7 @@ class ZippingSpliterator<L, R, O> implements Spliterator<O> {
     	if(newRights == null){
     		return null;
     	}
-    	return zipping(newLefts, newRights, combiner, isParallel);
+    	return zipping(newLefts, newRights, combiner);
     }
 
     @Override


### PR DESCRIPTION
I'm somewhat unsure of this particular implementation of trySplit(), If the second split fails, there should be some way to undo the split that occurred with the lefts to reconstruct the old spliterator, its a fairly edge case, and using normal streams I was unable to force it to occur. 

I was unable to find a way to test the ability of a stream to split without actually splitting it. 