### PR TITLE
MapStream API

### DIFF
--- a/src/main/java/com/codepoetics/protonpack/DefaultMapStream.java
+++ b/src/main/java/com/codepoetics/protonpack/DefaultMapStream.java
@@ -1,0 +1,249 @@
+/*
+ * Author: 		Alexis Cartier <alexcrt>
+ * Date :  		24 déc. 2014
+ */
+
+package com.codepoetics.protonpack;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collector;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+/**
+ * Default implementation of a {@code MapStream<K, V>}. 
+ */
+final class DefaultMapStream<K, V> implements MapStream<K, V> {
+
+    private final Stream<Entry<K, V>> delegate;
+
+    DefaultMapStream(Stream<Entry<K, V>> stream) {
+        delegate = stream;
+    }
+
+    @Override
+    public Iterator<Entry<K, V>> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public Spliterator<Entry<K, V>> spliterator() {
+        return delegate.spliterator();
+    }
+
+    @Override
+    public boolean isParallel() {
+        return delegate.isParallel();
+    }
+
+    @Override
+    public MapStream<K, V> sequential() {
+        return new DefaultMapStream<>(delegate.sequential());
+    }
+
+    @Override
+    public MapStream<K, V> parallel() {
+        return new DefaultMapStream<>(delegate.parallel());
+    }
+
+    @Override
+    public MapStream<K, V> unordered() {
+        return new DefaultMapStream<>(delegate.unordered());
+    }
+
+    @Override
+    public MapStream<K, V> onClose(Runnable closeHandler) {
+        return new DefaultMapStream<>(delegate.onClose(closeHandler));
+    }
+
+    @Override
+    public void close() {
+        delegate.close();        
+    }
+
+    @Override
+    public MapStream<K, V> filter(Predicate<? super Entry<K, V>> predicate) {
+        return new DefaultMapStream<>(delegate.filter(predicate));
+    }
+
+    @Override
+    public <R> Stream<R> map(Function<? super Entry<K, V>, ? extends R> mapper) {
+        return delegate.map(mapper);
+    }
+
+    @Override
+    public IntStream mapToInt(ToIntFunction<? super Entry<K, V>> mapper) {
+        return delegate.mapToInt(mapper);
+    }
+
+    @Override
+    public LongStream mapToLong(ToLongFunction<? super Entry<K, V>> mapper) {
+        return delegate.mapToLong(mapper);
+    }
+
+    @Override
+    public DoubleStream mapToDouble(ToDoubleFunction<? super Entry<K, V>> mapper) {
+        return delegate.mapToDouble(mapper);
+    }
+
+    @Override
+    public <R> Stream<R> flatMap(
+            Function<? super Entry<K, V>, ? extends Stream<? extends R>> mapper) {
+        return delegate.flatMap(mapper);
+    }
+
+    @Override
+    public IntStream flatMapToInt(
+            Function<? super Entry<K, V>, ? extends IntStream> mapper) {
+        return delegate.flatMapToInt(mapper);
+    }
+
+    @Override
+    public LongStream flatMapToLong(
+            Function<? super Entry<K, V>, ? extends LongStream> mapper) {
+        return delegate.flatMapToLong(mapper);
+    }
+
+    @Override
+    public DoubleStream flatMapToDouble(
+            Function<? super Entry<K, V>, ? extends DoubleStream> mapper) {
+        return delegate.flatMapToDouble(mapper);
+    }
+
+    @Override
+    public MapStream<K, V> distinct() {
+        return new DefaultMapStream<>(delegate.distinct());
+    }
+
+    @Override
+    public MapStream<K, V> sorted() {
+        return new DefaultMapStream<>(delegate.sorted());
+    }
+
+    @Override
+    public MapStream<K, V> sorted(Comparator<? super Entry<K, V>> comparator) {
+        return new DefaultMapStream<>(delegate.sorted(comparator));
+    }
+
+    @Override
+    public MapStream<K, V> peek(Consumer<? super Entry<K, V>> action) {
+        return new DefaultMapStream<>(delegate.peek(action));
+    }
+
+    @Override
+    public MapStream<K, V> limit(long maxSize) {
+        return new DefaultMapStream<>(delegate.limit(maxSize));
+    }
+
+    @Override
+    public MapStream<K, V> skip(long n) {
+        return new DefaultMapStream<>(delegate.skip(n));
+    }
+
+    @Override
+    public void forEach(Consumer<? super Entry<K, V>> action) {
+        delegate.forEach(action);
+    }
+
+    @Override
+    public void forEachOrdered(Consumer<? super Entry<K, V>> action) {
+        delegate.forEachOrdered(action);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return delegate.toArray();
+    }
+
+    @Override
+    public <A> A[] toArray(IntFunction<A[]> generator) {
+        return delegate.toArray(generator);
+    }
+
+    @Override
+    public Entry<K, V> reduce(Entry<K, V> identity,
+            BinaryOperator<Entry<K, V>> accumulator) {
+        return delegate.reduce(identity, accumulator);
+    }
+
+    @Override
+    public Optional<Entry<K, V>> reduce(BinaryOperator<Entry<K, V>> accumulator) {
+        return delegate.reduce(accumulator);
+    }
+
+    @Override
+    public <U> U reduce(U identity,
+            BiFunction<U, ? super Entry<K, V>, U> accumulator,
+            BinaryOperator<U> combiner) {
+        return delegate.reduce(identity, accumulator, combiner);
+    }
+
+    @Override
+    public <R> R collect(Supplier<R> supplier,
+            BiConsumer<R, ? super Entry<K, V>> accumulator,
+                    BiConsumer<R, R> combiner) {
+        return delegate.collect(supplier, accumulator, combiner);
+    }
+
+    @Override
+    public <R, A> R collect(Collector<? super Entry<K, V>, A, R> collector) {
+        return delegate.collect(collector);
+    }
+
+    @Override
+    public Optional<Entry<K, V>> min(Comparator<? super Entry<K, V>> comparator) {
+        return delegate.min(comparator);
+    }
+
+    @Override
+    public Optional<Entry<K, V>> max(Comparator<? super Entry<K, V>> comparator) {
+        return delegate.max(comparator);
+    }
+
+    @Override
+    public long count() {
+        return delegate.count();
+    }
+
+    @Override
+    public boolean anyMatch(Predicate<? super Entry<K, V>> predicate) {
+        return delegate.anyMatch(predicate);
+    }
+
+    @Override
+    public boolean allMatch(Predicate<? super Entry<K, V>> predicate) {
+        return delegate.allMatch(predicate);
+    }
+
+    @Override
+    public boolean noneMatch(Predicate<? super Entry<K, V>> predicate) {
+        return delegate.noneMatch(predicate);
+    }
+
+    @Override
+    public Optional<Entry<K, V>> findFirst() {
+        return delegate.findFirst();
+    }
+
+    @Override
+    public Optional<Entry<K, V>> findAny() {
+        return delegate.findAny();
+    }
+}

--- a/src/main/java/com/codepoetics/protonpack/MapStream.java
+++ b/src/main/java/com/codepoetics/protonpack/MapStream.java
@@ -1,0 +1,235 @@
+/*
+ * Author: 		Alexis Cartier <alexcrt>
+ * Date :  		24 déc. 2014
+*/
+
+package com.codepoetics.protonpack;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * A stream of {@code Map.Entry<K, V>}. 
+ */
+public interface MapStream<K, V> extends Stream<Entry<K, V>> {
+
+    /**
+     * Construct a {@code MapStream<K, V>} from the map
+     * @param map - the map to build the stream from
+     * @return a new {@code MapStream<K, V>}
+     */
+    public static <K, V> MapStream<K, V> of(Map<K, V> map) {
+        return new DefaultMapStream<>(map.entrySet().stream());
+    }
+    
+    /**
+     * Construct a {@code MapStream<K, V>} from the map
+     * @param map - the map to build the stream from
+     * @return a new {@code MapStream<K, V>}
+     */
+    @SafeVarargs
+    public static <K, V> MapStream<K, V> of(Map<K, V>... maps) {
+        return new DefaultMapStream<>(Stream.of(maps).flatMap(m -> m.entrySet().stream()));
+    }
+    
+    /**
+     * Construct a {@code MapStream<K, V>} from a single key-value pair
+     * @param key - the key
+     * @param value - the value
+     * @return a new {@code MapStream<K, V>}
+     */
+    public static <K, V> MapStream<K, V> of(K key, V value) {
+        return new DefaultMapStream<>(Stream.of(new SimpleImmutableEntry<>(key, value)));
+    }  
+    
+    /**
+     * Construct a {@code MapStream<K, V>} from a multiple key-value pairs
+     * @param key - key
+     * @param value - value
+     * @param key1 - key1
+     * @param value1 - value1
+     * @return a new {@code MapStream<K, V>}
+     */
+    public static <K, V> MapStream<K, V> of(K key, V value, K key1, V value1) {
+        return new DefaultMapStream<>(Stream.of(new SimpleImmutableEntry<>(key, value),
+                                                new SimpleImmutableEntry<>(key1, value1)));
+    }  
+    
+    /**
+     * Construct a {@code MapStream<K, V>} from a multiple key-value pairs
+     * @param key - key
+     * @param value - value
+     * @param key1 - key1
+     * @param value1 - value1
+     * @param key2 - key2
+     * @param value2 - value2
+     * @return a new {@code MapStream<K, V>}
+     */
+    public static <K, V> MapStream<K, V> of(K key, V value, K key1, V value1, K key2, V value2) {
+        return new DefaultMapStream<>(Stream.of(new SimpleImmutableEntry<>(key, value),
+                                                new SimpleImmutableEntry<>(key1, value1),
+                                                new SimpleImmutableEntry<>(key2, value2)));
+    }    
+    
+    /**
+     * Construct a {@code MapStream<K, V>} from a multiple key-value pairs
+     * @param key - key
+     * @param value - value
+     * @param key1 - key1
+     * @param value1 - value1
+     * @param key2 - key2
+     * @param value2 - value2
+     * @param key3 - key3
+     * @param value3 - value3
+     * @return a new {@code MapStream<K, V>}
+     */
+    public static <K, V> MapStream<K, V> of(K key, V value, K key1, V value1, K key2, V value2, K key3, V value3) {
+        return new DefaultMapStream<>(Stream.of(new SimpleImmutableEntry<>(key, value),
+                                                new SimpleImmutableEntry<>(key1, value1),
+                                                new SimpleImmutableEntry<>(key2, value2),
+                                                new SimpleImmutableEntry<>(key3, value3)));
+    }   
+    
+    /**
+     * Construct a {@code MapStream<K, V>} from a multiple key-value pairs
+     * @param key - key
+     * @param value - value
+     * @param key1 - key1
+     * @param value1 - value1
+     * @param key2 - key2
+     * @param value2 - value2
+     * @param key3 - key3
+     * @param value3 - value3
+     * @param key4 - key4
+     * @param value4 - value4
+     * @return a new {@code MapStream<K, V>}
+     */
+    public static <K, V> MapStream<K, V> of(K key, V value, K key1, V value1, K key2, V value2, K key3, V value3,  K key4, V value4) {
+        return new DefaultMapStream<>(Stream.of(new SimpleImmutableEntry<>(key, value),
+                                                new SimpleImmutableEntry<>(key1, value1),
+                                                new SimpleImmutableEntry<>(key2, value2),
+                                                new SimpleImmutableEntry<>(key3, value3),
+                                                new SimpleImmutableEntry<>(key4, value4)));
+    }   
+    
+    /**
+     * Applies the mapping for each keys in the map. If your mapping function is not bijective,
+     * make sure you call {@code mergeKeys} or that you provide a merge function when calling
+     * {@code collect}
+     * @param mapper - the key mapping to be applied
+     * @return a new MapStream
+     */
+    default <K1> MapStream<K1, V> mapKeys(Function<? super K, ? extends K1> mapper) {
+        return new DefaultMapStream<>(map(e -> new SimpleImmutableEntry<>(mapper.apply(e.getKey()), e.getValue())));
+    }
+    
+    /**
+     * Applies the mapping for each values in the map. 
+     * @param mapper - the value mapping to be applied
+     * @return a new MapStream
+     */
+    default <V1> MapStream<K, V1> mapValues(Function<? super V, ? extends V1> mapper) {
+        return new DefaultMapStream<>(map(e -> new SimpleImmutableEntry<>(e.getKey(), mapper.apply(e.getValue()))));
+    }
+    
+    /**
+     * Applies the mapping for each keys and values in the map. If your mapping function is not 
+     * bijective for the keys, make sure you call {@code mergeKeys} or that you provide a merge 
+     * function when calling {@code collect}.
+     * @param keyMapper - the key mapping to be applied
+     * @param valueMapper - the value mapping to be applied
+     * @return a new MapStream
+     */
+    default <K1, V1> MapStream<K1, V1> mapEntries(Function<? super K, ? extends K1> keyMapper, Function<? super V, ? extends V1> valueMapper) {
+        return new DefaultMapStream<>(map(e -> new SimpleImmutableEntry<>(keyMapper.apply(e.getKey()), valueMapper.apply(e.getValue()))));
+    }
+    
+    /**
+     * Merge keys of the Stream into a new Stream 
+     * @return a new MapStream
+     */
+    default MapStream<K, List<V>> mergeKeys() {
+        return of(collect(groupingBy(Entry::getKey, mapping(Entry::getValue, toList()))));
+    }
+    
+    /**
+     * Merge keys of the Stream into a new Stream with the merge function provided
+     * @return a new MapStream
+     */
+    default MapStream<K, V> mergeKeys(BinaryOperator<V> mergeFunction) {
+        return of(collect(mergeFunction));
+    }
+    
+    /**
+     * Return a Map from the stream. If you have similar keys in the stream,
+     * don't forget to call {@code mergeKeys()} or {@code collect (BinaryOperator<V> mergeFunction)}
+     * @return a map
+     */
+    default Map<K, V> collect() {
+        return collect(toMap(Entry::getKey, Entry::getValue));
+    }
+
+    /**
+    * Return a Map from the stream. If there are similar keys in the stream,
+    * the merge function will be applied to merge the values of those keys
+    * @param mergeFunction the function to merge the values if the keys are not unique
+    * @return a map
+    */
+    default Map<K, V> collect(BinaryOperator<V> mergeFunction) {
+        return collect(toMap(Entry::getKey, Entry::getValue, mergeFunction));
+    }
+
+    /**
+     * Return a MapStream from which the key and values are reversed.
+     * @return a new MapStream
+     */
+    default MapStream<V, K> inverseMapping() {
+        return new DefaultMapStream<>(map(e -> new SimpleImmutableEntry<>(e.getValue(), e.getKey())));
+    }
+    
+    @Override
+    MapStream<K, V> limit(long n);
+    
+    @Override
+    MapStream<K, V> skip(long n);
+    
+    @Override
+    MapStream<K, V> sorted();
+    
+    @Override
+    MapStream<K, V> sorted(Comparator<? super Entry<K, V>> comparator);
+    
+    @Override
+    MapStream<K, V> peek(Consumer<? super Entry<K, V>> action);
+    
+    @Override
+    MapStream<K, V> onClose(Runnable closeHandler);
+    
+    @Override
+    MapStream<K, V> filter(Predicate<? super Entry<K, V>> predicate);
+    
+    @Override
+    MapStream<K, V> parallel();
+    
+    @Override
+    MapStream<K, V> sequential();
+    
+    @Override
+    MapStream<K, V> unordered();
+    
+    @Override
+    MapStream<K, V> distinct();
+}

--- a/src/main/java/com/codepoetics/protonpack/MapStream.java
+++ b/src/main/java/com/codepoetics/protonpack/MapStream.java
@@ -41,7 +41,7 @@ public interface MapStream<K, V> extends Stream<Entry<K, V>> {
      * @return a new {@code MapStream<K, V>}
      */
     @SafeVarargs
-    public static <K, V> MapStream<K, V> of(Map<K, V>... maps) {
+    public static <K, V> MapStream<K, V> ofMaps(Map<K, V>... maps) {
         return new DefaultMapStream<>(Stream.of(maps).flatMap(m -> m.entrySet().stream()));
     }
     

--- a/src/test/java/com/codepoetics/protonpack/MapStreamTest.java
+++ b/src/test/java/com/codepoetics/protonpack/MapStreamTest.java
@@ -1,0 +1,78 @@
+/*
+ * Author: 		Alexis Cartier <alexcrt>
+ * Date :  		27 déc. 2014
+*/
+
+package com.codepoetics.protonpack;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class MapStreamTest {
+    
+    private MapStream<String, Integer> mapStream;
+    
+    @Before
+    public void setUp() {
+        mapStream = MapStream.of("John", 1, "Alice", 2);
+    }
+    
+    @Test
+    public void testMapKeys() {
+        Map<String, Integer> map = mapStream.mapKeys(x -> x.substring(2)).collect();
+        assertTrue(map.containsKey("hn"));
+        assertEquals(Integer.valueOf(1), map.get("hn"));
+    }
+    
+    @Test
+    public void testMapValues() {
+        Map<String, Integer> map = mapStream.mapValues(x -> x + 5).collect();
+        assertEquals(Integer.valueOf(6), map.get("John"));
+    }
+    
+    @Test
+    public void testMapEntries() {
+        Map<String, Integer> map = mapStream.mapEntries(x -> x.concat(" Doe"), i -> i%2).collect();
+        assertEquals(Integer.valueOf(1), map.get("John Doe"));
+        assertEquals(Integer.valueOf(0), map.get("Alice Doe"));
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testFailMergeKeys() {
+       mapStream.mapKeys(x -> Character.isUpperCase(x.charAt(0))).collect();
+    } 
+    
+    @Test
+    public void testMergeKeys() {
+        Map<Boolean, List<Integer>> map = mapStream.mapKeys(x -> Character.isUpperCase(x.charAt(0))).mergeKeys().collect();
+        assertEquals(Arrays.asList(1, 2), map.get(true));
+        assertEquals(null, map.get(false));
+    }
+    
+    @Test
+    public void testMergeKeysWithBinaryFunction() {
+        Map<Boolean, Integer> map = mapStream.mapKeys(x -> Character.isUpperCase(x.charAt(0))).mergeKeys(Integer::sum).collect();
+        assertEquals(Integer.valueOf(3), map.get(true));
+        assertEquals(null, map.get(false));
+    }
+    
+    @Test
+    public void testReverseMapping() {
+        Map<Integer, String> map = mapStream.inverseMapping().collect();
+        assertEquals("John", map.get(1));
+        assertEquals("Alice", map.get(2));
+        
+        map.put(3, "John");
+        
+        Map<String, Integer> mapReversed = MapStream.of(map).inverseMapping().collect(Integer::sum);
+        assertEquals(Integer.valueOf(4), mapReversed.get("John"));
+        assertEquals(Integer.valueOf(2), mapReversed.get("Alice"));
+    }
+}


### PR DESCRIPTION
I see a lot of questions on StackOverflow about how to reverse a map, merge multiple maps and so on. So I created a `MapStream` API for this.

## MapStream
A utility Stream for Maps. 

### Mapping Keys and Values

```java
Map<Integer, String> map = new HashMap<>();
map.put(1, "John");
map.put(2, "Alice");
map.put(3, "Bob");
        
MapStream.of(map)
         .mapKeys(x -> x % 2)
         .mergeKeys()
         .collect()
         .forEach((k, v) -> System.out.println(k+" => "+v));
```

will output:
```
0 => [Alice]
1 => [John, Bob]
```

### Static factory

Also it has a static factory, so if you are bored to always initialize a Map on multiple lines (and without the side effect of a double brace initialization), you can do it like this:

```java

Map<Integer, String> map = MapStream.of(1, "John", 2, "Alice", 3, "Bob").collect();
```

### Merging Values 

You can also supply a way to merge the values, either by providing a BinaryOperator when you call `mergeKeys` or `collect`, or by calling `mapValues`. This example show how to merge two lists from different maps which have the same keys by providing a BinaryOperator to `mergeKeys`:

```java
Map<String, List<Integer>> map1 = MapStream.of("Bob", Arrays.asList(1, 2)).collect();
Map<String, List<Integer>> map2 = MapStream.of("Bob", Arrays.asList(3, 4)).collect();
MapStream.ofMaps(map1, map2)
         .mergeKeys((l1, l2) -> Stream.concat(l1.stream(), l2.stream()).collect(toList()))
         .collect()
         .forEach((k, v) -> System.out.println(k+" => "+v));
```

which outputs:
```
Bob => [1, 2, 3, 4]
```

### InverseMapping

Obtaining a `Map<V, K>` from a `Map<K, V>`

```java
Map<String, Integer> map = MapStream.of("Bob", 1, "Alice", 2).collect();
Map<Integer, String> mapInversed = MapStream.of(map).inverseMapping().collect(); //1 => Bob ; 2 => Alice
```

Well I think it's an overall of the possibilites with this `MapStream` API.