### PR TITLE
Utility for converting Optionals to Streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ hs_err_pid*
 .project
 .classpath
 .settings
+
+# IntelliJ IDEA
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ assertThat(unfolded.collect(Collectors.toList()),
            contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 ```
 
-## of
+## stream
 
 Transforms a source type into a stream
 
-`of(Optional<T> optional):`
+`stream(Optional<T> optional):`
 ```java
-Stream<Item> items = idStream.flatMap(id -> StreamUtils.of(fetchItem(id));
+Stream<Item> items = idStream.flatMap(id -> StreamUtils.stream(fetchItem(id));
 ```

--- a/README.md
+++ b/README.md
@@ -79,3 +79,12 @@ Stream<Integer> unfolded = StreamUtils.unfold(1, i ->
 assertThat(unfolded.collect(Collectors.toList()),
            contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 ```
+
+## of
+
+Transforms a source type into a stream
+
+`of(Optional<T> optional):`
+```java
+Stream<Item> items = idStream.flatMap(id -> StreamUtils.of(fetchItem(id));
+```

--- a/src/main/java/com/codepoetics/protonpack/StreamUtils.java
+++ b/src/main/java/com/codepoetics/protonpack/StreamUtils.java
@@ -268,4 +268,14 @@ public final class StreamUtils {
     public static <T> Stream<List<T>> aggregateOnListCondition(Stream<T> source, BiPredicate<List<T>, T> predicate) {
         return StreamSupport.stream(new AggregatingSpliterator<T>(source.spliterator(), predicate), false);
     }
+
+    /**
+     * Converts an Optional value to a stream of 0..1 values
+     * @param optional source optional value
+     * @param <T> The type over the optional value
+     * @return Stream of the single item of type T or an empty stream
+     */
+    public static <T> Stream<T> of(Optional<T> optional) {
+        return optional.map(Stream::of).orElseGet(Stream::empty);
+    }
 }

--- a/src/main/java/com/codepoetics/protonpack/StreamUtils.java
+++ b/src/main/java/com/codepoetics/protonpack/StreamUtils.java
@@ -275,7 +275,7 @@ public final class StreamUtils {
      * @param <T> The type over the optional value
      * @return Stream of the single item of type T or an empty stream
      */
-    public static <T> Stream<T> of(Optional<T> optional) {
+    public static <T> Stream<T> stream(Optional<T> optional) {
         return optional.map(Stream::of).orElseGet(Stream::empty);
     }
 }

--- a/src/main/java/com/codepoetics/protonpack/Streamable.java
+++ b/src/main/java/com/codepoetics/protonpack/Streamable.java
@@ -33,7 +33,7 @@ public interface Streamable<T> {
     }
 
     static <T> Streamable<T> of(Optional<T> optional) {
-        return () -> StreamUtils.of(optional);
+        return () -> StreamUtils.stream(optional);
     }
 
     @SafeVarargs

--- a/src/main/java/com/codepoetics/protonpack/Streamable.java
+++ b/src/main/java/com/codepoetics/protonpack/Streamable.java
@@ -32,6 +32,10 @@ public interface Streamable<T> {
         return () -> StreamSupport.stream(iterable.spliterator(), false);
     }
 
+    static <T> Streamable<T> of(Optional<T> optional) {
+        return () -> StreamUtils.of(optional);
+    }
+
     @SafeVarargs
     static <T> Streamable<T> of(Streamable<T>...streamables) {
         return Stream.of(streamables).reduce(Streamable::concat).orElseGet(Streamable::empty);

--- a/src/test/java/com/codepoetics/protonpack/OptionalTest.java
+++ b/src/test/java/com/codepoetics/protonpack/OptionalTest.java
@@ -16,7 +16,7 @@ public class OptionalTest {
     public void
     stream_of_nonempty_optionals() {
         Stream<Integer> numbers = Stream.of(123, 456);
-        Stream<Integer> results = numbers.flatMap(n -> StreamUtils.of(maybeAdd3(n)));
+        Stream<Integer> results = numbers.flatMap(n -> StreamUtils.stream(maybeAdd3(n)));
         List<Integer> resultList = results.collect(Collectors.toList());
         assertEquals(Arrays.asList(126, 459), resultList);
     }
@@ -25,7 +25,7 @@ public class OptionalTest {
     public void
     stream_of_empty_optionals() {
         Stream<String> names = Stream.of("John", "Susan");
-        Stream<String> transformed = names.flatMap(s -> StreamUtils.of(Optional.empty()));
+        Stream<String> transformed = names.flatMap(s -> StreamUtils.stream(Optional.empty()));
         List<String> results = transformed.collect(Collectors.toList());
         assertEquals(Collections.emptyList(), results);
     }

--- a/src/test/java/com/codepoetics/protonpack/OptionalTest.java
+++ b/src/test/java/com/codepoetics/protonpack/OptionalTest.java
@@ -1,0 +1,37 @@
+package com.codepoetics.protonpack;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import static org.junit.Assert.*;
+
+public class OptionalTest {
+
+    @Test
+    public void
+    stream_of_nonempty_optionals() {
+        Stream<Integer> numbers = Stream.of(123, 456);
+        Stream<Integer> results = numbers.flatMap(n -> StreamUtils.of(maybeAdd3(n)));
+        List<Integer> resultList = results.collect(Collectors.toList());
+        assertEquals(Arrays.asList(126, 459), resultList);
+    }
+
+    @Test
+    public void
+    stream_of_empty_optionals() {
+        Stream<String> names = Stream.of("John", "Susan");
+        Stream<String> transformed = names.flatMap(s -> StreamUtils.of(Optional.empty()));
+        List<String> results = transformed.collect(Collectors.toList());
+        assertEquals(Collections.emptyList(), results);
+    }
+
+    private Optional<Integer> maybeAdd3(final Integer number) {
+        return Optional.of(number + 3);
+    }
+
+}

--- a/src/test/java/com/codepoetics/protonpack/StreamableTest.java
+++ b/src/test/java/com/codepoetics/protonpack/StreamableTest.java
@@ -2,6 +2,8 @@ package com.codepoetics.protonpack;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,5 +33,13 @@ public class StreamableTest {
         );
 
         assertThat(concatenated.toList(), contains(1, 2, 3, 5, 6, 7, 9, 10, 11));
+    }
+
+    @Test public void
+    streamable_of_optional() {
+        Streamable<Integer> streamableWithItem = Streamable.of(Optional.of(123));
+        Streamable<Integer> streamableEmpty = Streamable.of(Optional.empty());
+        assertEquals(Arrays.asList(123), streamableWithItem.toList());
+        assertEquals(Arrays.asList(), streamableEmpty.toList());
     }
 }


### PR DESCRIPTION
When calling a method that returns an `Optional<T>` for a `Stream<T>`it is useful to have a shorthand that converts the returned optional value to a stream of 0..1 items. E.g.

```java
Stream<Item> items = idStream.flatMap(id -> StreamUtils.of(fetchItem(id));
```

Implemented in StreamUtils class and Streamable interface.