### PR TITLE
Allow lesser size for the last windows in a windowed stream 

### DIFF
--- a/src/main/java/com/codepoetics/protonpack/StreamUtils.java
+++ b/src/main/java/com/codepoetics/protonpack/StreamUtils.java
@@ -161,6 +161,10 @@ public final class StreamUtils {
      * A skip of size 2 for a window of size 3 would look like
      * ([1, 2, 3], [3, 4, 5], ...)
      *
+     * If the stream finishes, the last window is guaranteed to be of the desired size (possible data loss).
+     *
+     * A stream [1, 2, 3] with a size 2 and skip 2 will result in ([1,2])
+     *
      * @param source The input stream
      * @param windowSize The window size
      * @param skip The skip amount between windows
@@ -168,7 +172,30 @@ public final class StreamUtils {
      * @return A stream of lists representing the windows
      */
     public static <T> Stream<List<T>> windowed(Stream<T> source, int windowSize, int skip){
-        return StreamSupport.stream(WindowedSpliterator.over(source.spliterator(), windowSize, skip), false);
+        return windowed(source, windowSize, skip, false);
+    }
+
+    /**
+     * Constructs a windowed stream where each element is a list of the window size
+     * and the skip is the offset from the start of each window.
+     *
+     * For example, a skip of size 1 is a traditional window a la ([1, 2, 3], [2, 3, 4] ...).
+     *
+     * A skip of size 2 for a window of size 3 would look like
+     * ([1, 2, 3], [3, 4, 5], ...)
+     *
+     * If the stream finishes, the last windows may have a window size lesser than the desired size. This is allowed
+     * via the allowLesserSize parameter.
+     *
+     * @param source The input stream
+     * @param windowSize The window size
+     * @param skip The skip amount between windows
+     * @param allowLesserSize Allow end of stream windows to have a lower size for completion
+     * @param <T> The type over which to stream
+     * @return A stream of lists representing the windows
+     */
+    public static <T> Stream<List<T>> windowed(Stream<T> source, int windowSize, int skip, boolean allowLesserSize){
+        return StreamSupport.stream(WindowedSpliterator.over(source.spliterator(), windowSize, skip, allowLesserSize), false);
     }
 
     /**

--- a/src/main/java/com/codepoetics/protonpack/WindowedSpliterator.java
+++ b/src/main/java/com/codepoetics/protonpack/WindowedSpliterator.java
@@ -9,19 +9,21 @@ class WindowedSpliterator<T> implements Spliterator<List<T>> {
     private final Spliterator<T> source;
     private final int windowSize;
     private int overlap;
+    private boolean allowLesserSize;
     List<T> queue = new LinkedList<>();
     List<T> next = new LinkedList<>();
     private boolean windowSeeded;
 
-    public WindowedSpliterator(Spliterator<T> input, int windowSize, int overlap) {
+    public WindowedSpliterator(Spliterator<T> input, int windowSize, int overlap, boolean allowLesserSize) {
         source = input;
 
         this.windowSize = windowSize;
         this.overlap = overlap;
+        this.allowLesserSize = allowLesserSize;
     }
 
-    static <T> WindowedSpliterator<T> over(Spliterator<T> source, int windowSize, int overlap) {
-        return new WindowedSpliterator<>(source, windowSize, overlap);
+    static <T> WindowedSpliterator<T> over(Spliterator<T> source, int windowSize, int overlap, boolean allowLesserSize) {
+        return new WindowedSpliterator<>(source, windowSize, overlap, allowLesserSize);
     }
 
     private boolean hasNext() {
@@ -63,8 +65,10 @@ class WindowedSpliterator<T> implements Spliterator<List<T>> {
 
         nextWindow();
 
-        if (next.size() != windowSize) {
-            next.clear();
+        if (!allowLesserSize) {
+            if (next.size() != windowSize) {
+                next.clear();
+            }
         }
 
         return queue;

--- a/src/test/java/com/codepoetics/protonpack/WindowedTest.java
+++ b/src/test/java/com/codepoetics/protonpack/WindowedTest.java
@@ -51,4 +51,33 @@ public class WindowedTest {
 
         assertThat(windows, iterableWithSize(0));
     }
+
+    @Test
+    public void
+    windowing_on_list_two_overlap_allow_lesser_size() {
+        Stream<Integer> integerStream = Stream.of(1, 2, 3, 4, 5);
+
+        List<List<Integer>> windows = StreamUtils.windowed(integerStream, 2, 2, true).collect(toList());
+
+        assertThat(windows, contains(
+                asList(1, 2),
+                asList(3, 4),
+                asList(5)));
+    }
+
+    @Test
+    public void
+    windowing_on_list_one_overlap_allow_lesser_size_multiple_lesser_windows() {
+        Stream<Integer> integerStream = Stream.of(1, 2, 3, 4, 5);
+
+        List<List<Integer>> windows = StreamUtils.windowed(integerStream, 3, 1, true).collect(toList());
+
+        assertThat(windows, contains(
+                asList(1, 2, 3),
+                asList(2, 3, 4),
+                asList(3, 4, 5),
+                asList(4, 5),
+                asList(5)));
+    }
+
 }


### PR DESCRIPTION
See issue #17 
Two tests added (one for simple data loss, the other one for multiple lesser size sliding windows)