### PR TITLE
Add MapStream.mapEntries(BiFunction) to combine key and value

### DIFF
--- a/src/main/java/com/codepoetics/protonpack/maps/MapStream.java
+++ b/src/main/java/com/codepoetics/protonpack/maps/MapStream.java
@@ -172,7 +172,13 @@ public interface MapStream<K, V> extends Stream<Entry<K, V>> {
     default <K1, V1> MapStream<K1, V1> mapEntries(Function<? super K, ? extends K1> keyMapper, Function<? super V, ? extends V1> valueMapper) {
         return new DefaultMapStream<>(map(e -> new SimpleImmutableEntry<>(keyMapper.apply(e.getKey()), valueMapper.apply(e.getValue()))));
     }
-
+    
+    /**
+     * Applies the mapping for each (key, value) pair in the map.
+     * @param mapper the mapping function to be applied
+     * @param <R> the type to map the (key, value) pairs into
+     * @return a new Stream
+     */
     default <R> Stream<R> mapEntries(BiFunction<? super K, ? super V, ? extends R> mapper) {
         return map(e -> mapper.apply(e.getKey(), e.getValue()));
     }

--- a/src/main/java/com/codepoetics/protonpack/maps/MapStream.java
+++ b/src/main/java/com/codepoetics/protonpack/maps/MapStream.java
@@ -173,8 +173,8 @@ public interface MapStream<K, V> extends Stream<Entry<K, V>> {
         return new DefaultMapStream<>(map(e -> new SimpleImmutableEntry<>(keyMapper.apply(e.getKey()), valueMapper.apply(e.getValue()))));
     }
 
-    default <K, V, R> Stream<R> mapEntries(BiFunction<? super K, ? super V, ? extends R> mapper) {
-        return map(e -> mapper.apply((K)e.getKey(), (V)e.getValue()));
+    default <R> Stream<R> mapEntries(BiFunction<? super K, ? super V, ? extends R> mapper) {
+        return map(e -> mapper.apply(e.getKey(), e.getValue()));
     }
     
     /**

--- a/src/main/java/com/codepoetics/protonpack/maps/MapStream.java
+++ b/src/main/java/com/codepoetics/protonpack/maps/MapStream.java
@@ -10,6 +10,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -170,6 +171,10 @@ public interface MapStream<K, V> extends Stream<Entry<K, V>> {
      */
     default <K1, V1> MapStream<K1, V1> mapEntries(Function<? super K, ? extends K1> keyMapper, Function<? super V, ? extends V1> valueMapper) {
         return new DefaultMapStream<>(map(e -> new SimpleImmutableEntry<>(keyMapper.apply(e.getKey()), valueMapper.apply(e.getValue()))));
+    }
+
+    default <K, V, R> Stream<R> mapEntries(BiFunction<? super K, ? super V, ? extends R> mapper) {
+        return map(e -> mapper.apply((K)e.getKey(), (V)e.getValue()));
     }
     
     /**

--- a/src/test/java/com/codepoetics/protonpack/MapStreamTest.java
+++ b/src/test/java/com/codepoetics/protonpack/MapStreamTest.java
@@ -5,8 +5,12 @@
 
 package com.codepoetics.protonpack;
 
+import static java.util.stream.Collectors.toList;
+
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,6 +47,12 @@ public class MapStreamTest {
         Map<String, Integer> map = mapStream.mapEntries(x -> x.concat(" Doe"), i -> i%2).collect();
         assertEquals(Integer.valueOf(1), map.get("John Doe"));
         assertEquals(Integer.valueOf(0), map.get("Alice Doe"));
+    }
+    
+    @Test
+    public void testMapEntriesWithBiFunction() {
+        List<String> list = mapStream.mapEntries((k, v) -> k + " " + v).collect(toList());
+        assertThat(list, contains("John 1", "Alice 2"));
     }
     
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
Obtain a Stream of objects created by applying a BiFunction to each key/value pair.
Addresses #27 

I'm not sure my Generics knowledge is sufficient to get this quite right… I don't understand why the cast is needed. Please feel free to correct it :)