### PR TITLE
Add uniqueNullable to CollectorUtils

### DIFF
--- a/src/main/java/com/codepoetics/protonpack/collectors/CollectorUtils.java
+++ b/src/main/java/com/codepoetics/protonpack/collectors/CollectorUtils.java
@@ -92,6 +92,22 @@ public final class CollectorUtils {
         );
     }
 
+    /**
+     * A collector that returns the single member of a stream (or null if not present), or throws a
+     * {@link com.codepoetics.protonpack.collectors.NonUniqueValueException} if more
+     * than one item is found.
+     * @param <T> The type of the items in the stream.
+     * @return The collector.
+     */
+    public static <T> Collector<T, AtomicReference<T>, T> uniqueNullable() {
+        return Collector.of(
+                AtomicReference::new,
+                CollectorUtils::uniqueAccumulate,
+                CollectorUtils::uniqueCombine,
+                AtomicReference::get
+        );
+    }
+
     private static <T> void uniqueAccumulate(AtomicReference<T> a, T t) {
         if (t == null) {
             return;

--- a/src/test/java/com/codepoetics/protonpack/UniqueTest.java
+++ b/src/test/java/com/codepoetics/protonpack/UniqueTest.java
@@ -22,6 +22,11 @@ public class UniqueTest {
         assertThat(Stream.of(1, 2, 3).filter(i -> i > 2).collect(CollectorUtils.unique()), equalTo(Optional.of(3)));
     }
 
+    @Test public void
+    returns_unique_nullable_item(){
+        assertThat(Stream.of(1, 2, 3).filter(i -> i > 2).collect(CollectorUtils.uniqueNullable()), equalTo(3));
+    }
+
     @Test(expected=NonUniqueValueException.class) public void
     throws_exception_if_item_is_not_unique() {
         Stream.of(1, 2, 3).filter(i -> i > 1).collect(CollectorUtils.unique());


### PR DESCRIPTION
Add `CollectorUtils.uniqueNullable()` method to be able to use it with `Collectors.groupingBy()`.

Before:
```java
Map<String, Optional<Object>> map = list.stream().collect(
   Collectors.groupingBy(
	Object::toString,
	CollectorUtils.unique()
   )
)
```

After:
```java
Map<String, Object> map = list.stream().collect(
   Collectors.groupingBy(
	Object::toString,
	CollectorUtils.uniqueNullable()
   )
)
```