### PR TITLE
added MapStream filterKeys and filterValues

### DIFF
--- a/src/main/java/com/codepoetics/protonpack/maps/MapStream.java
+++ b/src/main/java/com/codepoetics/protonpack/maps/MapStream.java
@@ -245,37 +245,45 @@ public interface MapStream<K, V> extends Stream<Entry<K, V>> {
     default MapStream<V, K> inverseMapping() {
         return new DefaultMapStream<>(map(e -> new SimpleImmutableEntry<>(e.getValue(), e.getKey())));
     }
-    
+
+    default MapStream<K, V> filterKeys(Predicate<K> predicate) {
+        return filter(e -> predicate.test(e.getKey()));
+    }
+
+    default MapStream<K, V> filterValues(Predicate<V> predicate) {
+        return filter(e -> predicate.test(e.getValue()));
+    }
+
     @Override
     MapStream<K, V> limit(long n);
-    
+
     @Override
     MapStream<K, V> skip(long n);
-    
+
     @Override
     MapStream<K, V> sorted();
-    
+
     @Override
     MapStream<K, V> sorted(Comparator<? super Entry<K, V>> comparator);
-    
+
     @Override
     MapStream<K, V> peek(Consumer<? super Entry<K, V>> action);
-    
+
     @Override
     MapStream<K, V> onClose(Runnable closeHandler);
-    
+
     @Override
     MapStream<K, V> filter(Predicate<? super Entry<K, V>> predicate);
-    
+
     @Override
     MapStream<K, V> parallel();
-    
+
     @Override
     MapStream<K, V> sequential();
-    
+
     @Override
     MapStream<K, V> unordered();
-    
+
     @Override
     MapStream<K, V> distinct();
 }

--- a/src/test/java/com/codepoetics/protonpack/MapStreamTest.java
+++ b/src/test/java/com/codepoetics/protonpack/MapStreamTest.java
@@ -13,12 +13,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 public class MapStreamTest {
     
@@ -100,5 +102,23 @@ public class MapStreamTest {
         Map<String, Integer> mapReversed = MapStream.of(map).inverseMapping().collect(Integer::sum);
         assertEquals(Integer.valueOf(4), mapReversed.get("John"));
         assertEquals(Integer.valueOf(2), mapReversed.get("Alice"));
+    }
+
+    @Test
+    public void testFilterKeys() {
+        Predicate<String> predicate = s -> s.length() < 5;
+        Map<String, Integer> map = mapStream.filterKeys(predicate).collect();
+
+        assertNull(map.get("Alice"));
+        assertEquals(Integer.valueOf(1),map.get("John"));
+    }
+
+    @Test
+    public void testFilterValues() {
+        Predicate<Integer> predicate = i -> i == 1;
+        Map<String, Integer> map = mapStream.filterValues(predicate).collect();
+
+        assertNull(map.get("Alice"));
+        assertEquals(Integer.valueOf(1),map.get("John"));
     }
 }


### PR DESCRIPTION
Hi,

This is a helpful shortcut to filter entries without dealing with the extraction of key or value.

I know it adds to the maintenance but it is a common pattern I had everywhere.

Per tests:
```java
mapStream.filterKeys(predicate).collect();
...
mapStream.filterValues(predicate).collect();
```

Thanks